### PR TITLE
Update Cassandra and AstraDB pages

### DIFF
--- a/docs/extensions-integrations/directory/database-tutorials/cassandra/apache-cassandra.md
+++ b/docs/extensions-integrations/directory/database-tutorials/cassandra/apache-cassandra.md
@@ -12,14 +12,15 @@ For more information, see the [Apache Cassandra](https://cassandra.apache.org) p
 
 ## Supported database versions
 
-The extension's JDBC wrapper uses the Java Driver for Apache Cassandra® 4.4.0 or greater which is designed for
+The extension's JDBC wrapper uses the Java Driver for Apache Cassandra® which is designed for:
 
 * Apache Cassandra® 2.1+
+* DataStax Enterprise (5.0+)
 
 It will throw "unsupported feature" exceptions if used against an older version of Cassandra cluster.
 
 For more information, please check the 
-[compatibility matrix](https://docs.datastax.com/en/driver-matrix/doc/driver_matrix/javaDrivers.html) and read the 
+[compatibility matrix](https://docs.datastax.com/en/driver-matrix/docs/java-drivers.html) and read the 
 [driver documentation](https://docs.datastax.com/en/developer/java-driver/latest/).
 
 --8<-- "database-tutorial-prerequisites.md"

--- a/docs/extensions-integrations/directory/database-tutorials/cassandra/datastax-astra-db.md
+++ b/docs/extensions-integrations/directory/database-tutorials/cassandra/datastax-astra-db.md
@@ -4,12 +4,7 @@ title: DataStax Astra DB
 
 # Using Liquibase with DataStax Astra DB (powered by Apache Cassandra)
 
-
 [DataStax Astra DB](https://www.datastax.com/products/datastax-astra) is a multi-cloud DBaaS built on Apache Cassandra. Astra DB simplifies cloud-native Cassandra application development and reduces deployment time from weeks to minutes. For more information, see [DataStax Astra DB Documentation](https://docs.datastax.com/en/astra/docs/index.html).
-
-## Supported database versions
-
-* DataStax Enterprise (5.0+)
 
 --8<-- "database-tutorial-prerequisites.md"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ extra:
   extension_version:
     cassandra: 4.25.0.1
   jdbc_driver_version:
-    cassandra: 4.10.2
+    cassandra: 4.11.0
 
 extra_css:
   - css/shared.css


### PR DESCRIPTION
Hello,

Regarding the supported versions of AstraDB, I deleted the section because AstraDB is based on open-source Apache Cassandra and not DSE and as explained [here](https://docs.datastax.com/en/astra-serverless/docs/astra-faq.html#_how_is_astra_db_different_from_dse), and there is no public versioning for AstraDB afaik. Also, I moved the minimal version of DSE into the Cassandra page, which makes more sense.

I also fixed the link to the compatibility matrix to directly point to the matrix for the Java driver.

Finally, I updated the Maven part to take into account the latest version of the driver.