### PR TITLE
removed a redirect associated with the db2onz page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ plugins:
         'extensions-integrations/directory/tutorials/cloud-spanner.md': 'extensions-integrations/directory/database-tutorials/cloud-spanner.md'
         'extensions-integrations/directory/tutorials/cockroachdb.md': 'extensions-integrations/directory/database-tutorials/cockroachdb.md'
         'extensions-integrations/directory/tutorials/cosmosdb.md': 'extensions-integrations/directory/database-tutorials/cosmosdb.md'
-        'extensions-integrations/directory/tutorials/db2onz.md': 'extensions-integrations/directory/database-tutorials/db2onz.md'
         'extensions-integrations/directory/tutorials/db2onzdeploy-sql.md': 'extensions-integrations/directory/database-tutorials/db2onzdeploy-sql.md'
         'extensions-integrations/directory/tutorials/firebird.md': 'extensions-integrations/directory/database-tutorials/firebird.md'
         'extensions-integrations/directory/tutorials/h2.md': 'extensions-integrations/directory/database-tutorials/h2.md'


### PR DESCRIPTION
I deleted a file in another merge, but I didn't realize that there was a redirect for that file in another file that now is causing the site to be unable to build so I'm removing the redirect here.