### PR TITLE
[DAT-22829] Update contributor docs branch references from master to main

### DIFF
--- a/docs/code/get-started/create-pr.md
+++ b/docs/code/get-started/create-pr.md
@@ -6,7 +6,7 @@ title: Create a Pull Request
 
 ## Contributing Etiquette
 
-Please see our [Contributor Code of Conduct](https://github.com/liquibase/liquibase/blob/master/CODE_OF_CONDUCT.md){:target="_blank"} for information on our rules of conduct.
+Please see our [Contributor Code of Conduct](https://github.com/liquibase/liquibase/blob/main/CODE_OF_CONDUCT.md){:target="_blank"} for information on our rules of conduct.
 
 ## Requirements
 
@@ -63,8 +63,8 @@ The normal flow through this board is:
         - "Test" as manual testing is done (if required)
     - If there are any questions or concerns found during this process, the team will comment on the PR so please watch your notifications
     - When everything passes, the PR will be moved to "Ready to Merge"
-4. After the PR has moved to the "Ready to Merge" column, it will be merged to "master"
-    - The master branch is always kept in an "always releasable" state, regardless of when the next release will be
+4. After the PR has moved to the "Ready to Merge" column, it will be merged to "main"
+    - The main branch is always kept in an "always releasable" state, regardless of when the next release will be
     - As release dates approach, the team may keep some PRs in "Ready to Merge" until the next release depending on the code freeze status
 5. Once the PR is merged, it moves to "Done"
     - Merged PRs will go out in the next release

--- a/docs/code/get-started/env-setup.md
+++ b/docs/code/get-started/env-setup.md
@@ -65,7 +65,7 @@ You can tell the build worked successfully if you see something like this at the
 [INFO] ------------------------------------------------------------------------
 ```
 
-It's always good to ensure you can successfully run the CLI from the current master branch before making changes locally.
+It's always good to ensure you can successfully run the CLI from the current main branch before making changes locally.
 
 
 ## Running Builds

--- a/docs/code/test-your-code/integration-tests.md
+++ b/docs/code/test-your-code/integration-tests.md
@@ -43,7 +43,7 @@ Write classic integration tests when:
 
 ## Classic Integration Tests
 
-The [liquibase-integration-tests](https://github.com/liquibase/liquibase/tree/master/liquibase-integration-tests){:target="_blank"} submodule in the Liquibase repository contains
+The [liquibase-integration-tests](https://github.com/liquibase/liquibase/tree/main/liquibase-integration-tests){:target="_blank"} submodule in the Liquibase repository contains
 the original and still often-used set of "classic" integration tests.
 
 The goal of these integration tests is to ensure common functionality works across all database types that ship with Liquibase Core as well as test database-specific functionality.

--- a/docs/code/test-your-code/test-environments.md
+++ b/docs/code/test-your-code/test-environments.md
@@ -7,7 +7,7 @@ title: Test Environments
 ## Overview
 
 To make it easy to spin up standardized test environments for testing, Liquibase has an abstraction around [testcontainers.org](https://testcontainers.org){:target="_blank"}
-at [liquibase/extension/testing/testsystem](https://github.com/liquibase/liquibase/tree/master/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem){:target="_blank"}.
+at [liquibase/extension/testing/testsystem](https://github.com/liquibase/liquibase/tree/main/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem){:target="_blank"}.
 
 The wrapper around Test Containers allows us to provide a simple configuration system, plus support testing databases that do not have Docker containers such as in-memory and cloud databases.
 
@@ -17,7 +17,7 @@ The wrapper around Test Containers allows us to provide a simple configuration s
 
 ## Configuration
 
-The default test environments and settings are configured in [liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml](https://github.com/liquibase/liquibase/tree/master/liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml){:target="_blank"}.
+The default test environments and settings are configured in [liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml](https://github.com/liquibase/liquibase/tree/main/liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml){:target="_blank"}.
 
 That file configures the various databases including docker image settings and users to create. Generally, each test system will be created with:
 
@@ -47,7 +47,7 @@ For example, by default the MysqlIntegrationTest will skip all tests because `li
 
 ### Configuration Structure
 
-All settings for the test environments use the `liquibase.sdk.testSystem` prefix. The overall structure can be seen in the [liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml](https://github.com/liquibase/liquibase/tree/master/liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml){:target="_blank"} file.
+All settings for the test environments use the `liquibase.sdk.testSystem` prefix. The overall structure can be seen in the [liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml](https://github.com/liquibase/liquibase/tree/main/liquibase-extension-testing/src/main/resources/liquibase.sdk.yaml){:target="_blank"} file.
 
 For each test environment, there is a top-level "key" for it. For example, `liquibase.sdk.testSystem.mysql`. There is also a `liquibase.sdk.testSystem.default` section which contains default/standard settings.
 

--- a/docs/code/test-your-code/unit-tests.md
+++ b/docs/code/test-your-code/unit-tests.md
@@ -40,7 +40,7 @@ is empty, then return null.
 ### The Java class to test
 
 See the actual Java class in
-GitHub [StringUtil.java](https://github.com/liquibase/liquibase/blob/master/liquibase-core/src/main/java/liquibase/util/StringUtil.java)
+GitHub [StringUtil.java](https://github.com/liquibase/liquibase/blob/main/liquibase-core/src/main/java/liquibase/util/StringUtil.java)
 {target="_blank"}
 or the edited example below:
 
@@ -81,7 +81,7 @@ public class StringUtil { // ...
 ### The unit test
 
 See the actual Unit Test class in
-GitHub [StringUtilTest.groovy](https://github.com/liquibase/liquibase/blob/master/liquibase-core/src/test/groovy/liquibase/util/StringUtilTest.groovy)
+GitHub [StringUtilTest.groovy](https://github.com/liquibase/liquibase/blob/main/liquibase-core/src/test/groovy/liquibase/util/StringUtilTest.groovy)
 {target="_blank"}
 or the edited example below:
 


### PR DESCRIPTION
## Summary

- Update 9 references to `master` branch across 5 contributor documentation files to use `main`
- Fixes GitHub URLs pointing to `liquibase/liquibase/blob/master/` and `tree/master/`
- Updates text references telling contributors to target the `master` branch

## Files Changed

- `docs/code/get-started/env-setup.md` — "current master branch" → "current main branch"
- `docs/code/get-started/create-pr.md` — CODE_OF_CONDUCT URL, "merged to master", "master branch is always kept..."
- `docs/code/test-your-code/integration-tests.md` — GitHub tree URL
- `docs/code/test-your-code/test-environments.md` — 3 GitHub tree URLs
- `docs/code/test-your-code/unit-tests.md` — 2 GitHub blob URLs

## Context

Part of DAT-22090 (enterprise-wide master→main migration). This PR should be merged after DAT-22091 (liquibase/liquibase branch rename) so the URLs resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)