### PR TITLE
DAT-22796: Contribute docs update to specify community expectations on issue resolution

### DIFF
--- a/docs/code/.pages
+++ b/docs/code/.pages
@@ -1,6 +1,7 @@
 nav:
     - index.md
     - report-an-issue.md
+    - issue-resolution-expectations.md
     - "Get Started": get-started
     - "Test Your Code": test-your-code
     - architecture

--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -16,6 +16,7 @@ For over a decade, we’ve had people from around the world help out in so many 
 Spotted a bug? Follow our process on logging it in GitHub Issues.
 
 [Submit an Issue](report-an-issue.md){ .md-button }
+[Issue Resolution Expectations](issue-resolution-expectations.md){ .md-button }
 
 ## Contribute code
 

--- a/docs/code/issue-resolution-expectations.md
+++ b/docs/code/issue-resolution-expectations.md
@@ -30,9 +30,16 @@ The difference between an issue that gets resolved quickly and one that sits for
 
 ### Provide a Detailed Analysis
 
-Rather than just reporting a bug, investigate and document where in the codebase the problem might be. This dramatically reduces the time anyone needs to implement a fix.
+Rather than just reporting a bug, investigate and document what is happening as precisely as you can. Even without a development background, a well-written analysis dramatically reduces the time needed to diagnose and fix an issue.
 
-A useful analysis might include:
+**For everyone:** Document the behavior in as much detail as possible:
+
+- The exact inputs you provided (changelog, command, configuration)
+- The exact output or error you received
+- What you expected to happen instead
+- Whether the behavior changes with different Liquibase versions, databases, or environments
+
+**If you are familiar with the Liquibase codebase or Java development**, you can go deeper:
 
 - **Which class, method, or module** is likely involved
 - **What is happening vs. what should happen** at the code level
@@ -55,44 +62,59 @@ sequenceDiagram
     RollbackCommand-->>CLI: result
 ```
 
-You do not need to be a core contributor to produce a useful diagram. Documenting the flow and highlighting where things go wrong is a valuable contribution on its own.
+You do not need to be a developer to produce a useful diagram — even a hand-drawn flow of "I did X, then Y happened, but I expected Z" communicates valuable information. Documenting the flow and highlighting where things go wrong is a contribution on its own.
 
 ### Clarify the Scope of the Issue
 
-When a bug is reported, it is often unclear whether it affects one database, several, or all of them. Clarifying the scope helps everyone understand the real impact and prioritize accordingly.
+When a bug is reported, it is often unclear whether it affects one database, several, or all of them. Sharing what you know — even if it is just your own experience — helps everyone understand how widespread the problem is and how urgently it should be addressed.
 
-Consider investigating and documenting:
+Here are some things worth sharing in an issue comment, based on whatever you happen to know or have access to:
 
-- **Which databases are affected?** If the issue was reported for PostgreSQL, does it also occur on Oracle, MySQL, H2, or SQL Server?
-- **Which Liquibase versions are affected?** Is this a long-standing bug or a regression? If a regression, when did it first appear?
-- **Which execution environments are affected?** CLI only, Maven plugin, Gradle, Spring Boot, or all of them?
-- **How widespread is the impact?** Is this a narrow edge case or something many users are likely to encounter?
+- **If you have access to multiple database types**, try reproducing the issue on them and share what you find. For example: "I confirmed this also happens on MySQL — it is not just PostgreSQL."
+- **If you have tried multiple Liquibase versions**, note whether the problem exists in all of them or only in a specific version. If it worked before and broke recently, that is a very useful signal.
+- **If you use Liquibase in more than one way** (for example, both from the command line and via a Maven build), share whether the problem shows up in all of them or just one.
+- **If you can describe how common the scenario is**, that helps too — for example, "this is a pattern many teams use" or "this is a very specific edge case in our setup."
 
-Even a brief comment like "Confirmed on PostgreSQL 15 and MySQL 8, not reproducible on H2" is extremely helpful for anyone working on the fix.
+None of these require a technical background — you are simply sharing your own experience. Even a brief comment like "I can only reproduce this with the CLI, not with Maven" is exactly the kind of information that shapes how a fix is approached.
 
 ### Perform a Risk Assessment
 
-Understanding what could break when a fix is applied is just as important as understanding the bug itself. A risk assessment helps contributors implement safer fixes and helps reviewers approve them with confidence.
+Before a fix is implemented, it helps to think about what else might be affected. This kind of reflection — often called a risk assessment — helps contributors make safer changes and helps reviewers approve them with more confidence. You do not need an engineering background to contribute here; some of the most useful input comes from people who simply know the product well.
 
-A useful risk assessment considers:
+**For everyone:** Think about and share what else in your workflow might be affected by a change. For example:
+
+- Are there other commands or operations that do something similar and might be impacted?
+- Have you seen related behavior elsewhere in Liquibase that a fix might accidentally change?
+- Is this something many teams are likely to rely on, or a rare edge case?
+
+Sharing those observations as a comment on the issue — even informally — is genuinely useful.
+
+**If you are a Java developer**, you can extend the assessment to the code level:
 
 - **Affected areas of code** — which classes, modules, or components would a fix need to touch?
 - **Regression risk** — could changing this behavior break other scenarios? Which tests or use cases might be affected?
-- **Database compatibility** — if the fix changes SQL generation or snapshot behavior, could it have unintended effects on other databases?
 - **Changelog compatibility** — could the fix change how existing changelogs are interpreted or cause checksum differences?
 - **Extension and API impact** — does the fix touch any public APIs or extension points that downstream projects depend on?
 
-A risk assessment does not need to be exhaustive. Even a brief note like "this change is isolated to `PostgresDatabaseSnapshotGenerator` and should not affect other databases" gives meaningful guidance to anyone planning to implement or review the fix.
+A risk assessment does not need to be exhaustive. Even a short note like "this seems to only affect snapshot generation for PostgreSQL and should not change behavior for other databases" gives meaningful guidance to anyone planning to implement or review the fix.
 
 ### Contribute Tests
 
-One of the highest-value contributions you can make is writing tests — even if you never touch the production code. Tests:
+One of the highest-value contributions you can make is helping ensure that a fix is well covered by tests — even if you never write a single line of code. Tests:
 
-- **Document the bug** — a failing test is clear, reproducible proof of the problem
-- **Prevent regressions** — once the fix is in, passing tests ensure the problem does not come back
-- **Accelerate review** — PRs with good test coverage are easier to evaluate and merge
+- **Document the bug** — a clear, reproducible case is proof the problem exists
+- **Prevent regressions** — once a fix is in, tests ensure the problem does not silently come back
+- **Accelerate review** — well-covered changes are easier to evaluate and merge with confidence
 
-Liquibase uses the [Spock testing framework](https://spockframework.org/){:target="_blank"} for both unit and integration tests. See our guides for:
+**For everyone:** Think about the scenarios that triggered the bug and describe them in the issue. What were you doing when it happened? What inputs, configurations, or sequences of steps were involved? Are there related scenarios that a fix should also handle correctly?
+
+Sharing these use cases — even in plain language — is genuinely useful. A developer writing tests can use your scenarios directly as a checklist to make sure the fix is fully covered. For example:
+
+> "This happens when `createTable` runs on a schema that already exists. It would also be worth checking: what happens if the table exists but with different columns? What if the schema name contains special characters?"
+
+That kind of input shapes the test coverage even if you never open a code editor.
+
+**If you are a Java developer**, consider writing the tests directly. Liquibase uses the [Spock testing framework](https://spockframework.org/){:target="_blank"} for both unit and integration tests. See our guides for:
 
 - [Writing unit tests](test-your-code/unit-tests.md)
 - [Writing integration tests](test-your-code/integration-tests.md)

--- a/docs/code/issue-resolution-expectations.md
+++ b/docs/code/issue-resolution-expectations.md
@@ -1,0 +1,125 @@
+---
+title: Issue Resolution Expectations
+---
+
+# Issue Resolution & Community Collaboration
+
+## Every Contribution Matters
+
+Liquibase is built by and for its community. Every bug report, analysis, code contribution, and test written makes Liquibase better for everyone. We are deeply grateful for the time and effort that contributors bring to this project — whether you have been here for years or this is your first interaction.
+
+We also want to be honest and transparent with you about how the project works, so that we can collaborate more effectively together.
+
+## Understanding Team Capacity
+
+Like many open-source projects, the Liquibase engineering team balances a wide range of priorities. While we are committed to the health of the open-source project, our bandwidth to individually implement fixes for every reported issue is limited. This is not because we don't care — quite the opposite. It means we rely on, and deeply value, the community's help to keep the project moving forward.
+
+The Liquibase team is committed to:
+
+- Triaging issues and providing initial feedback
+- Guiding community contributors who are working on a fix
+- Reviewing analyses, pull requests, and test contributions
+- Answering questions on issue threads and [Discord](https://discord.gg/pDB5DfE){:target="_blank"}
+- Implementing fixes when team capacity and priorities allow, focusing on severity and community impact
+
+The most effective way to get an issue resolved faster is community involvement — and there are many ways to contribute that do not require writing a full fix.
+
+## How the Community Can Help
+
+The difference between an issue that gets resolved quickly and one that sits for months often comes down to community engagement. Here are the highest-impact ways to move an issue forward:
+
+### Provide a Detailed Analysis
+
+Rather than just reporting a bug, investigate and document where in the codebase the problem might be. This dramatically reduces the time anyone needs to implement a fix.
+
+A useful analysis might include:
+
+- **Which class, method, or module** is likely involved
+- **What is happening vs. what should happen** at the code level
+- **A sequence diagram** tracing the execution flow for the scenario that fails
+
+Sequence diagrams are particularly valuable for understanding complex interactions. For example, if a `rollback` command behaves differently across two databases, a diagram tracing the call chain can pinpoint exactly where the paths diverge:
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant CommandChain
+    participant RollbackCommand
+    participant SQLGenerator
+
+    CLI->>CommandChain: execute("rollback")
+    CommandChain->>RollbackCommand: run()
+    RollbackCommand->>SQLGenerator: generateSQL(change, database)
+    Note over SQLGenerator: Behavior diverges here<br/>between PostgreSQL and Oracle
+    SQLGenerator-->>RollbackCommand: SQL statement
+    RollbackCommand-->>CLI: result
+```
+
+You do not need to be a core contributor to produce a useful diagram. Documenting the flow and highlighting where things go wrong is a valuable contribution on its own.
+
+### Clarify the Scope of the Issue
+
+When a bug is reported, it is often unclear whether it affects one database, several, or all of them. Clarifying the scope helps everyone understand the real impact and prioritize accordingly.
+
+Consider investigating and documenting:
+
+- **Which databases are affected?** If the issue was reported for PostgreSQL, does it also occur on Oracle, MySQL, H2, or SQL Server?
+- **Which Liquibase versions are affected?** Is this a long-standing bug or a regression? If a regression, when did it first appear?
+- **Which execution environments are affected?** CLI only, Maven plugin, Gradle, Spring Boot, or all of them?
+- **How widespread is the impact?** Is this a narrow edge case or something many users are likely to encounter?
+
+Even a brief comment like "Confirmed on PostgreSQL 15 and MySQL 8, not reproducible on H2" is extremely helpful for anyone working on the fix.
+
+### Perform a Risk Assessment
+
+Understanding what could break when a fix is applied is just as important as understanding the bug itself. A risk assessment helps contributors implement safer fixes and helps reviewers approve them with confidence.
+
+A useful risk assessment considers:
+
+- **Affected areas of code** — which classes, modules, or components would a fix need to touch?
+- **Regression risk** — could changing this behavior break other scenarios? Which tests or use cases might be affected?
+- **Database compatibility** — if the fix changes SQL generation or snapshot behavior, could it have unintended effects on other databases?
+- **Changelog compatibility** — could the fix change how existing changelogs are interpreted or cause checksum differences?
+- **Extension and API impact** — does the fix touch any public APIs or extension points that downstream projects depend on?
+
+A risk assessment does not need to be exhaustive. Even a brief note like "this change is isolated to `PostgresDatabaseSnapshotGenerator` and should not affect other databases" gives meaningful guidance to anyone planning to implement or review the fix.
+
+### Contribute Tests
+
+One of the highest-value contributions you can make is writing tests — even if you never touch the production code. Tests:
+
+- **Document the bug** — a failing test is clear, reproducible proof of the problem
+- **Prevent regressions** — once the fix is in, passing tests ensure the problem does not come back
+- **Accelerate review** — PRs with good test coverage are easier to evaluate and merge
+
+Liquibase uses the [Spock testing framework](https://spockframework.org/){:target="_blank"} for both unit and integration tests. See our guides for:
+
+- [Writing unit tests](test-your-code/unit-tests.md)
+- [Writing integration tests](test-your-code/integration-tests.md)
+
+!!! tip
+    A pull request that only adds a failing test to demonstrate a bug — with no fix yet — is a welcome and valuable contribution. It reduces uncertainty for whoever picks up the fix next.
+
+## What to Expect
+
+We want to be transparent about realistic expectations when you open an issue or submit a contribution:
+
+| Contribution | What to expect |
+|---|---|
+| **Bug report** | Triage and initial feedback; fix timeline depends on severity, impact, and community involvement |
+| **Feature request** | Review and discussion; implementation depends on roadmap fit and community interest |
+| **Issue analysis or scope report** | Reviewed and acknowledged; directly helps prioritize and accelerate a fix |
+| **Risk assessment** | Reviewed as part of the issue discussion; aids both contributors and reviewers |
+| **Pull request** | Initial review feedback, followed by a full review cycle (see [PR Review Process](get-started/create-pr.md#pr-review-process)) |
+| **Test contribution** | Welcomed and reviewed; may be merged independently ahead of the full fix |
+
+If you are waiting on an issue that is important to you, the most effective action is to contribute new information — a better reproduction case, an analysis, a scope report, a risk assessment, or an offer to help implement the fix.
+
+## Getting Help
+
+If you have questions about an issue or need guidance on contributing a fix, reach out:
+
+- **GitHub issue comments** — for code-level questions and discussion directly tied to a specific issue
+- **[Discord](https://discord.gg/pDB5DfE){:target="_blank"}** — join the Liquibase server for real-time conversation with team members and the broader community
+
+Thank you for being part of the Liquibase community. Every contribution — no matter how small — helps make Liquibase better for everyone.

--- a/docs/code/report-an-issue.md
+++ b/docs/code/report-an-issue.md
@@ -2,26 +2,100 @@
 title: Report an Issue
 ---
 
-# How to report an issue in Liquibase
+# How to Report an Issue
 
-Liquibase Core is the main library for the Liquibase community. 
+The Liquibase community is stronger when issues are well-documented. Whether you've encountered a bug or have a new feature idea, following these guidelines helps everyone — from the person who will triage it to the contributor who will eventually fix it.
 
-Have a question about using Liquibase? Please ask on the [Liquibase Forum](http://forum.liquibase.org/){:target="_blank"}, or in the [Liquibase Discord](https://discord.gg/pDB5DfE){:target="_blank"}.
+## Step 1: Search for an Existing Issue
 
-If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/liquibase/liquibase/issues?utf8=%E2%9C%93&q=is%3Aissue){:target="_blank"}. 
-You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
+Before opening a new issue, please search to see if it has already been reported. Duplicate issues split the conversation and make it harder to track progress.
 
-_**Note:** Liquibase previously used [Liquibase Core Jira Issues](https://liquibase.jira.com/browse/CORE){:target="_blank"}. We will maintain both sets of issues until we have been able to fix them or move them to the new GitHub Issues location. You can still comment on issues there, but no new issues can be created._
+Search [GitHub Issues](https://github.com/liquibase/liquibase/issues?utf8=%E2%9C%93&q=is%3Aissue){:target="_blank"} — the primary and only community tracker we use. **Always include closed issues in your search**, as the problem may have been addressed with a workaround or explanation.
 
-## Step-by-step instructions
+### Search Tips
 
-**1 –** Navigate to the [create a new issue](https://github.com/liquibase/liquibase/issues/new/choose){:target="_blank"} page.
+Different search terms can surface different results. Try multiple approaches:
 
-**2 –** Click the `Get started` button next to "Bug Report or Feature request".
+| Search by | Example queries |
+|---|---|
+| Error message | `"Unexpected error running Liquibase"` |
+| Change type | `createTable`, `addColumn`, `dropIndex` |
+| Database name | `postgres`, `oracle`, `mysql`, `sqlserver` |
+| Command or operation | `update`, `rollback`, `diff`, `generateChangelog` |
+| Combined terms | `createTable postgres "column not found"` |
 
-![New issue](images/new-issue.png)
+GitHub's search filters can narrow results further:
 
-**3 –** Fill out the bug report template.
+- `is:open` / `is:closed` — filter by issue state
+- `label:bug` — filter by label
+- `author:username` — find issues from a specific reporter
 
-**4 –** Receive updates on your issue.
+If you find an existing issue that matches your problem:
 
+- **React with :thumbsup:** to signal your interest — this helps the team and community prioritize.
+- **Add a comment** with your specific environment details and reproduction steps if they differ from what's already documented.
+- **Share new information** such as logs, database versions, workarounds you've discovered, or additional affected scenarios.
+
+## Step 2: Report a New Issue
+
+If no existing issue matches what you've found, [open a new issue](https://github.com/liquibase/liquibase/issues/new/choose){:target="_blank"} and select the "Bug Report or Feature Request" template.
+
+### What Makes a Great Bug Report?
+
+A great bug report allows someone who has never seen your environment to reproduce and understand the problem. The more context you provide, the faster the community and team can help.
+
+#### Environment Information
+
+Include as much of the following as possible:
+
+- **Liquibase version** — run `liquibase --version`
+- **Database type and version** — e.g., PostgreSQL 15.2, Oracle 19c, MySQL 8.0, SQL Server 2019
+- **JDBC driver name and version**
+- **Java version** — run `java -version`
+- **Operating system and version**
+- **How Liquibase is invoked** — CLI, Maven plugin, Gradle plugin, Spring Boot integration, etc.
+
+#### Steps to Reproduce
+
+Provide a minimal, self-contained reproduction:
+
+1. A simple changelog file that demonstrates the issue (reduce it to as few change sets as possible)
+2. The exact command or configuration used
+3. Clear step-by-step instructions to trigger the problem
+
+!!! tip
+    The simpler and more self-contained the reproduction, the faster it can be diagnosed. If your changelog has 50 change sets but only one is relevant, please trim it down. A minimal example is one of the most valuable things you can provide.
+
+#### Actual vs. Expected Behavior
+
+Describe clearly:
+
+- What you **expected** to happen
+- What **actually** happened
+
+Avoid vague descriptions like "it doesn't work" — be specific about the outcome, including any error messages or incorrect behavior.
+
+#### Logs and Output
+
+Include complete error messages and stack traces. Use code blocks for readability:
+
+````
+```
+Your log output or stack trace here
+```
+````
+
+For more detailed diagnostic output, run Liquibase with `--log-level=DEBUG`. This often reveals what is happening internally and is very helpful when diagnosing unexpected behavior.
+
+!!! note "Have a question rather than a bug?"
+    Please ask directly on the issue thread or join us on [Discord](https://discord.gg/pDB5DfE){:target="_blank"} — that is where the Liquibase team and community are most active.
+
+## Step 3: Help Move the Issue Forward
+
+Filing an issue is just the beginning. Issues get resolved much more quickly when reporters and other community members stay engaged. After filing, consider:
+
+- **Clarifying the scope** — does this affect only the database you tested, or other databases as well?
+- **Providing an analysis** — where do you think the problem might be in the code?
+- **Adding a failing test** — even without a fix, a test that reproduces the issue is a meaningful contribution.
+
+For more on how you can help move an issue toward a fix and what to expect from the team, see [Issue Resolution Expectations](issue-resolution-expectations.md).


### PR DESCRIPTION
Some updates were made to the contribute site repo to clarify what the community would expect when someone reports an issue. This was already done, but I added some more details to this page. Also, a new issue resolution expectation was created to clarify what the expectation would be (steps that need to be performed) to get an issue fixed.

